### PR TITLE
Add offline fallback message for chatbot

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
 NEXT_PUBLIC_GA_ID=G-5VJ2NJ8TVR
 NEXT_PUBLIC_FORMSPREE_ENDPOINT=https://formspree.io/f/mgvzkren
 NEXT_PUBLIC_RECAPTCHA_SITE_KEY=6Lemto8rAAAAANZ8X8pVGufZddz0jQpehCcdm1KK
-AWS_API_URL=https://nwcx62awx3.execute-api.ap-southeast-2.amazonaws.com/Prod/chat  
+AWS_API_URL=https://nwcx62awx3.execute-api.ap-southeast-2.amazonaws.com/Prod/chat

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -6,15 +6,11 @@ export async function POST(req: Request) {
 
     console.log("Received message:", message);
 
-    const response = await fetch(process.env.AWS_API_URL!, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ message }),
+    // Return a static response since the AWS backend is currently unavailable
+    return NextResponse.json({
+      reply:
+        "I'm currently offline as my backend is being updated. Please reach out via the contact form instead!",
     });
-
-    const data = await response.json();
-
-    return NextResponse.json(data);
   } catch (error) {
     console.error("Error in chat API:", error);
     return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });


### PR DESCRIPTION
The AWS account providing the API Gateway endpoint was closed, which resulted in `403 Forbidden` responses being sent back to the Next.js API route. I have modified `src/app/api/chat/route.ts` to skip the fetch request and instead provide a graceful, static offline message that the chatbot component can display to users. Also cleaned up trailing whitespace on `AWS_API_URL` in `.env`.

---
*PR created automatically by Jules for task [8166151743934330005](https://jules.google.com/task/8166151743934330005) started by @ParagNaikade*