### PR TITLE
Integrate Gemini AI model for chatbot backend

### DIFF
--- a/.env
+++ b/.env
@@ -2,3 +2,4 @@ NEXT_PUBLIC_GA_ID=G-5VJ2NJ8TVR
 NEXT_PUBLIC_FORMSPREE_ENDPOINT=https://formspree.io/f/mgvzkren
 NEXT_PUBLIC_RECAPTCHA_SITE_KEY=6Lemto8rAAAAANZ8X8pVGufZddz0jQpehCcdm1KK
 AWS_API_URL=https://nwcx62awx3.execute-api.ap-southeast-2.amazonaws.com/Prod/chat  
+GEMINI_API_KEY=your_api_key_here

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@google/generative-ai": "^0.24.1",
     "@vercel/analytics": "^1.6.1",
     "clsx": "^2.1.1",
     "framer-motion": "^12.23.9",

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -17,7 +17,7 @@ export async function POST(req: Request) {
     }
 
     const genAI = new GoogleGenerativeAI(apiKey);
-    const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash" });
+    const model = genAI.getGenerativeModel({ model: "gemini-2.0-flash" });
 
     const result = await model.generateContent(message);
     const reply = result.response.text();

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -17,7 +17,7 @@ export async function POST(req: Request) {
     }
 
     const genAI = new GoogleGenerativeAI(apiKey);
-    const model = genAI.getGenerativeModel({ model: "gemini-pro" });
+    const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash" });
 
     const result = await model.generateContent(message);
     const reply = result.response.text();

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -17,7 +17,7 @@ export async function POST(req: Request) {
     }
 
     const genAI = new GoogleGenerativeAI(apiKey);
-    const model = genAI.getGenerativeModel({ model: "gemini-2.0-flash" });
+    const model = genAI.getGenerativeModel({ model: "gemini-pro" });
 
     const result = await model.generateContent(message);
     const reply = result.response.text();

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { GoogleGenerativeAI } from "@google/generative-ai";
 
 export async function POST(req: Request) {
   try {
@@ -6,15 +7,22 @@ export async function POST(req: Request) {
 
     console.log("Received message:", message);
 
-    const response = await fetch(process.env.AWS_API_URL!, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ message }),
-    });
+    const apiKey = process.env.GEMINI_API_KEY;
+    if (!apiKey) {
+      console.error("GEMINI_API_KEY is not defined in environment variables");
+      return NextResponse.json(
+        { error: "API key configuration missing" },
+        { status: 500 }
+      );
+    }
 
-    const data = await response.json();
+    const genAI = new GoogleGenerativeAI(apiKey);
+    const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash" });
 
-    return NextResponse.json(data);
+    const result = await model.generateContent(message);
+    const reply = result.response.text();
+
+    return NextResponse.json({ reply });
   } catch (error) {
     console.error("Error in chat API:", error);
     return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });

--- a/src/components/Chatbot.tsx
+++ b/src/components/Chatbot.tsx
@@ -242,15 +242,15 @@ export default function Chatbot() {
     while (i < fragment.length) {
       const code = fragment.indexOf("`", i);
       if (code === -1) {
-        parts.push(renderBoldItalic(fragment.slice(i)));
+        parts.push(<React.Fragment key={`text-${i}`}>{renderBoldItalic(fragment.slice(i))}</React.Fragment>);
         break;
       }
 
-      if (code > i) parts.push(renderBoldItalic(fragment.slice(i, code)));
+      if (code > i) parts.push(<React.Fragment key={`text-${i}-${code}`}>{renderBoldItalic(fragment.slice(i, code))}</React.Fragment>);
 
       const end = fragment.indexOf("`", code + 1);
       if (end === -1) {
-        parts.push(renderBoldItalic(fragment.slice(code)));
+        parts.push(<React.Fragment key={`text-${code}`}>{renderBoldItalic(fragment.slice(code))}</React.Fragment>);
         break;
       }
 
@@ -285,16 +285,16 @@ export default function Chatbot() {
       })();
 
       if (!next) {
-        out.push(fragment.slice(i));
+        out.push(<React.Fragment key={`frag-${i}`}>{fragment.slice(i)}</React.Fragment>);
         break;
       }
 
-      if (next.idx > i) out.push(fragment.slice(i, next.idx));
+      if (next.idx > i) out.push(<React.Fragment key={`frag-${i}-${next.idx}`}>{fragment.slice(i, next.idx)}</React.Fragment>);
 
       if (next.kind === "b") {
         const end = fragment.indexOf("**", next.idx + 2);
         if (end === -1) {
-          out.push(fragment.slice(next.idx));
+          out.push(<React.Fragment key={`frag-${next.idx}`}>{fragment.slice(next.idx)}</React.Fragment>);
           break;
         }
         out.push(
@@ -306,7 +306,7 @@ export default function Chatbot() {
       } else {
         const end = fragment.indexOf("*", next.idx + 1);
         if (end === -1) {
-          out.push(fragment.slice(next.idx));
+          out.push(<React.Fragment key={`frag-${next.idx}`}>{fragment.slice(next.idx)}</React.Fragment>);
           break;
         }
         out.push(

--- a/yarn.lock
+++ b/yarn.lock
@@ -76,6 +76,11 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.1.tgz#de633db3ec2ef6a3c89e2f19038063e8a122e2c2"
   integrity sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==
 
+"@google/generative-ai@^0.24.1":
+  version "0.24.1"
+  resolved "https://registry.yarnpkg.com/@google/generative-ai/-/generative-ai-0.24.1.tgz#634a3c06f8ea7a6125c1b0d6c1e66bb11afb52c9"
+  integrity sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==
+
 "@humanwhocodes/config-array@^0.13.0":
   version "0.13.0"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.13.0.tgz#fb907624df3256d04b9aa2df50d7aa97ec648748"


### PR DESCRIPTION
Replaced the legacy AWS-hosted chatbot backend with a direct integration to Google's Gemini AI model (`gemini-1.5-flash`) using the official `@google/generative-ai` SDK. Updated the API route (`src/app/api/chat/route.ts`) to handle requests and fallback errors, and added `GEMINI_API_KEY` to the `.env` template.

This ensures the chatbot continues functioning after the AWS account closure.

---
*PR created automatically by Jules for task [3290551965165226645](https://jules.google.com/task/3290551965165226645) started by @ParagNaikade*